### PR TITLE
Trigger deployments automatically on PR merge, scoped to changed code

### DIFF
--- a/.github/workflows/deploy-be-to-azure.yml
+++ b/.github/workflows/deploy-be-to-azure.yml
@@ -1,0 +1,52 @@
+name: Deploy to Docker to Azure Container Registry
+on:
+    workflow_dispatch:
+        inputs:
+            environment:
+                description: 'Environment to deploy to'
+                required: true
+                default: 'development'
+                type: choice
+                options:
+                    - production
+                    - staging
+                    - development
+                    - testing
+jobs:
+
+    set-github-environment:
+        runs-on: ubuntu-latest
+        outputs:
+            environment: ${{ steps.set-env.outputs.target_env }}
+        steps:
+            - name: Set Environment
+              id: set-env
+              run: |
+                case "${{ inputs.environment }}" in
+                    testing)     echo "target_env=Testing" >> $GITHUB_OUTPUT ;;
+                    development) echo "target_env=dev" >> $GITHUB_OUTPUT ;;
+                    staging)     echo "target_env=stage" >> $GITHUB_OUTPUT ;;
+                    production)  echo "target_env=prod" >> $GITHUB_OUTPUT ;;
+                esac
+    build-and-deploy:
+        needs: set-github-environment
+        runs-on: ubuntu-latest
+        environment: ${{ needs.set-github-environment.outputs.environment }}
+        steps:
+            - name: Checkout Code
+              uses: actions/checkout@v3
+              with:
+                ref: ${{ github.event.inputs.environment }}
+            - name: Login to Azure Container Registry
+              uses: azure/docker-login@v1
+              with:
+                login-server: ${{ vars.DOCKERHUB_REGISTRY }}
+                username: ${{ secrets.DOCKERHUB_USERNAME }}
+                password: ${{ secrets.DOCKERHUB_TOKEN }}
+            - name: Build and Push Docker Image
+              id: build-and-push
+              working-directory: ./backend
+              run: |
+                docker build -t ${{ secrets.DOCKERHUB_REGISTRY }}/${{ secrets.DOCKERHUB_REPOSITORY }}:${{ github.sha }} -t ${{ secrets.DOCKERHUB_REGISTRY }}/${{ secrets.DOCKERHUB_REPOSITORY }}:${{ needs.set-github-environment.outputs.environment }} .
+                docker push ${{ secrets.DOCKERHUB_REGISTRY }}/${{ secrets.DOCKERHUB_REPOSITORY }} --all-tags
+    

--- a/.github/workflows/deploy-be-to-azure.yml
+++ b/.github/workflows/deploy-be-to-azure.yml
@@ -12,6 +12,12 @@ on:
                     - staging
                     - development
                     - testing
+    workflow_call:
+        inputs:
+            environment:
+                description: 'Environment to deploy to'
+                required: true
+                type: string
 jobs:
 
     set-github-environment:

--- a/.github/workflows/deploy-be-to-azure.yml
+++ b/.github/workflows/deploy-be-to-azure.yml
@@ -41,12 +41,12 @@ jobs:
               uses: azure/docker-login@v1
               with:
                 login-server: ${{ vars.DOCKERHUB_REGISTRY }}
-                username: ${{ secrets.DOCKERHUB_USERNAME }}
+                username: ${{ vars.DOCKERHUB_USERNAME }}
                 password: ${{ secrets.DOCKERHUB_TOKEN }}
             - name: Build and Push Docker Image
               id: build-and-push
               working-directory: ./backend
               run: |
-                docker build -t ${{ secrets.DOCKERHUB_REGISTRY }}/${{ secrets.DOCKERHUB_REPOSITORY }}:${{ github.sha }} -t ${{ secrets.DOCKERHUB_REGISTRY }}/${{ secrets.DOCKERHUB_REPOSITORY }}:${{ needs.set-github-environment.outputs.environment }} .
-                docker push ${{ secrets.DOCKERHUB_REGISTRY }}/${{ secrets.DOCKERHUB_REPOSITORY }} --all-tags
+                docker build -t ${{ vars.DOCKERHUB_REGISTRY }}/${{ vars.DOCKERHUB_REPOSITORY }}:${{ github.sha }} -t ${{ vars.DOCKERHUB_REGISTRY }}/${{ vars.DOCKERHUB_REPOSITORY }}:${{ needs.set-github-environment.outputs.environment }} .
+                docker push ${{ vars.DOCKERHUB_REGISTRY }}/${{ vars.DOCKERHUB_REPOSITORY }} --all-tags
     

--- a/.github/workflows/deploy-fe-to-azure.yml
+++ b/.github/workflows/deploy-fe-to-azure.yml
@@ -1,0 +1,70 @@
+name: Deploy to Azure Static Web Apps
+on:
+    workflow_dispatch:
+        inputs:
+            environment:
+                description: 'Environment to deploy to'
+                required: true
+                default: 'development'
+                type: choice
+                options:
+                    - production
+                    - staging
+                    - development
+                    - testing
+jobs:
+
+    set-github-environment:
+        runs-on: ubuntu-latest
+        outputs:
+            environment: ${{ steps.set-env.outputs.target_env }}
+        steps:
+            - name: Set Environment
+              id: set-env
+              run: |
+                case "${{ inputs.environment }}" in
+                    testing)     echo "target_env=Testing" >> $GITHUB_OUTPUT ;;
+                    development) echo "target_env=dev" >> $GITHUB_OUTPUT ;;
+                    staging)     echo "target_env=stage" >> $GITHUB_OUTPUT ;;
+                    production)  echo "target_env=prod" >> $GITHUB_OUTPUT ;;
+                esac
+   
+    build-and-deploy:
+        needs: set-github-environment
+        runs-on: ubuntu-latest
+        environment: ${{ needs.set-github-environment.outputs.environment }}
+        steps:
+            - name: Checkout Code
+              uses: actions/checkout@v3
+              with:
+                ref: ${{ github.event.inputs.environment }}
+            - name: Setup Node.js
+              uses: actions/setup-node@v3
+              with:
+                node-version: '24'
+            - name: Install Dependencies
+              working-directory: ./frontend
+              run: npm install
+            - name: Ingest Environment Variables
+              working-directory: ./frontend
+              run: |
+                touch .env
+                echo '${{ vars.ENV_CONFIG }}' | jq -r 'to_entries | map("\(.key)=\(.value)") | .[]' > .env
+                echo CI=false >> .env
+            - name: Build Project
+              working-directory: ./frontend
+              run: npm run build
+            - name: Copy WebApp Config
+              working-directory: ./frontend
+              run: cp staticwebapp.config.json dist/staticwebapp.config.json
+            
+            - name: Deploy to Azure Static Web Apps
+              id: deploy
+              uses: Azure/static-web-apps-deploy@v1
+              with:
+                    azure_static_web_apps_api_token: ${{ secrets.AZURE_DEPLOYMENT_TOKEN }}
+                    action: "upload"
+                    app_location: "./frontend/dist" # App source code path
+                    api_location: "" # Api source code path - optional
+                    output_location: "" # Built app content directory - optional
+                    skip_app_build: true

--- a/.github/workflows/deploy-fe-to-azure.yml
+++ b/.github/workflows/deploy-fe-to-azure.yml
@@ -12,6 +12,12 @@ on:
                     - staging
                     - development
                     - testing
+    workflow_call:
+        inputs:
+            environment:
+                description: 'Environment to deploy to'
+                required: true
+                type: string
 jobs:
 
     set-github-environment:

--- a/.github/workflows/trigger-deploy-on-merge.yml
+++ b/.github/workflows/trigger-deploy-on-merge.yml
@@ -1,0 +1,51 @@
+name: Trigger Deployment on Pull Request Merge
+on:
+    pull_request:
+        types: [closed]
+        branches: [develop, staging, production, testing]
+jobs:
+
+    on-merge:
+        if: github.event.pull_request.merged == true
+        runs-on: ubuntu-latest
+        outputs:
+            environment: ${{ steps.set-env.outputs.environment }}
+            backend-changed: ${{ steps.filter.outputs.backend }}
+            frontend-changed: ${{ steps.filter.outputs.frontend }}
+        steps:
+            - name: Map target branch to environment
+              id: set-env
+              run: |
+                case "${{ github.base_ref }}" in
+                    develop)    echo "environment=development" >> $GITHUB_OUTPUT ;;
+                    staging)    echo "environment=staging" >> $GITHUB_OUTPUT ;;
+                    production) echo "environment=production" >> $GITHUB_OUTPUT ;;
+                    testing)    echo "environment=testing" >> $GITHUB_OUTPUT ;;
+                esac
+            - name: Check which code changed
+              id: filter
+              uses: dorny/paths-filter@v3
+              with:
+                filters: |
+                    backend:
+                        - 'backend/**'
+                        - '.github/workflows/deploy-be-to-azure.yml'
+                    frontend:
+                        - 'frontend/**'
+                        - '.github/workflows/deploy-fe-to-azure.yml'
+
+    deploy-backend:
+        needs: on-merge
+        if: needs.on-merge.outputs.backend-changed == 'true'
+        uses: ./.github/workflows/deploy-be-to-azure.yml
+        with:
+            environment: ${{ needs.on-merge.outputs.environment }}
+        secrets: inherit
+
+    deploy-frontend:
+        needs: on-merge
+        if: needs.on-merge.outputs.frontend-changed == 'true'
+        uses: ./.github/workflows/deploy-fe-to-azure.yml
+        with:
+            environment: ${{ needs.on-merge.outputs.environment }}
+        secrets: inherit

--- a/frontend/staticwebapp.config.json
+++ b/frontend/staticwebapp.config.json
@@ -1,0 +1,5 @@
+{
+    "navigationFallback": {
+        "rewrite": "/index.html"
+    }
+}


### PR DESCRIPTION
## What

Adds automatic deployment triggering when a pull request is merged into `develop`, `staging`, `production`, or `testing`. Only the workflows whose code actually changed are triggered — a frontend-only PR deploys just the frontend, a backend-only PR deploys just the backend, and a PR touching both deploys both in parallel.

## Changes

- **New workflow `trigger-deploy-on-merge.yml`**
  - Runs on `pull_request: closed` against `develop`, `staging`, `production`, and `testing`; proceeds only if the PR was actually merged (not just closed).
  - Maps the target branch to the environment name the deploy workflows expect (e.g. `develop` → `development`).
  - Uses `dorny/paths-filter@v3` to detect whether the merged PR changed `backend/**` or `frontend/**` (each deploy workflow's own file is included in its filter).
  - Calls the matching deploy workflow(s) as reusable workflows with `secrets: inherit`.