### PR TITLE
workflow changed

### DIFF
--- a/.github/workflows/trigger-deploy-on-merge.yml
+++ b/.github/workflows/trigger-deploy-on-merge.yml
@@ -3,6 +3,10 @@ on:
     pull_request:
         types: [closed]
         branches: [develop, staging, production, testing]
+permissions:
+    contents: read
+    actions: write
+
 jobs:
 
     on-merge:
@@ -38,15 +42,28 @@ jobs:
     deploy-backend:
         needs: on-merge
         if: needs.on-merge.outputs.backend-changed == 'true'
-        uses: ./.github/workflows/deploy-be-to-azure.yml
-        with:
-            environment: ${{ needs.on-merge.outputs.environment }}
-        secrets: inherit
-
+        runs-on: ubuntu-latest
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        steps:
+            - name: Trigger Backend Deployment Workflow
+              run: |
+                gh workflow run deploy-be-to-azure.yml \
+                    --ref ${{ github.base_ref }} \
+                    --field environment=${{ needs.on-merge.outputs.environment }}
     deploy-frontend:
         needs: on-merge
         if: needs.on-merge.outputs.frontend-changed == 'true'
-        uses: ./.github/workflows/deploy-fe-to-azure.yml
-        with:
-            environment: ${{ needs.on-merge.outputs.environment }}
-        secrets: inherit
+        runs-on: ubuntu-latest
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        steps:
+            - name: Trigger Frontend Deployment Workflow
+              run: |
+                gh workflow run deploy-fe-to-azure.yml \
+                    --ref ${{ github.base_ref }} \
+                    --field environment=${{ needs.on-merge.outputs.environment }}
+        # uses: ./.github/workflows/deploy-fe-to-azure.yml
+        # with:
+        #     environment: ${{ needs.on-merge.outputs.environment }}
+        # secrets: inherit

--- a/frontend/public/style.css
+++ b/frontend/public/style.css
@@ -65,4 +65,3 @@ input[type="checkbox"] {
     color: white;
     background-color: #586AB5;
   }
-  /* Minor change for testing front-end deployment */


### PR DESCRIPTION
This pull request updates the deployment workflow for both the backend and frontend, shifting from using reusable workflows to directly invoking deployments via the GitHub CLI. It also adds explicit permissions for the workflow and removes a test comment from the frontend CSS.

**GitHub Actions workflow improvements:**

* Switched the `deploy-backend` and `deploy-frontend` jobs from using reusable workflows (`uses: ./.github/workflows/deploy-*.yml`) to running deployment triggers via the GitHub CLI (`gh workflow run ...`). This change provides more flexibility and control over deployment triggers.
* Added explicit workflow permissions for `contents: read` and `actions: write` to the deployment workflow, ensuring the workflow has the necessary access for deployment operations.

**Frontend code cleanup:**

* Removed a minor test comment from `frontend/public/style.css` that was used for testing front-end deployment.Changed workflow trigger to gh client