### PR TITLE
repo link added as workflow failed

### DIFF
--- a/.github/workflows/trigger-deploy-on-merge.yml
+++ b/.github/workflows/trigger-deploy-on-merge.yml
@@ -49,6 +49,7 @@ jobs:
             - name: Trigger Backend Deployment Workflow
               run: |
                 gh workflow run deploy-be-to-azure.yml \
+                    --repo ${{ github.repository }} \
                     --ref ${{ github.base_ref }} \
                     --field environment=${{ needs.on-merge.outputs.environment }}
     deploy-frontend:
@@ -61,6 +62,7 @@ jobs:
             - name: Trigger Frontend Deployment Workflow
               run: |
                 gh workflow run deploy-fe-to-azure.yml \
+                    --repo ${{ github.repository }} \
                     --ref ${{ github.base_ref }} \
                     --field environment=${{ needs.on-merge.outputs.environment }}
         # uses: ./.github/workflows/deploy-fe-to-azure.yml

--- a/frontend/public/style.css
+++ b/frontend/public/style.css
@@ -65,3 +65,4 @@ input[type="checkbox"] {
     color: white;
     background-color: #586AB5;
   }
+  /* Minor change for testing front-end deployment */


### PR DESCRIPTION
Repo link added
This pull request introduces minor improvements to the deployment workflow configuration and a small front-end style file update. The main changes ensure that the correct repository is specified when triggering backend and frontend deployment workflows, and a comment was added to the CSS for testing purposes.

**Deployment workflow improvements:**

* Added the `--repo ${{ github.repository }}` flag to both backend and frontend deployment workflow triggers in `.github/workflows/trigger-deploy-on-merge.yml` to explicitly specify the repository when running the deployment workflows. [[1]](diffhunk://#diff-91591205e33ebfe3a7bd2bfde881b4685447349450408744f68879d6c480f51cR52) [[2]](diffhunk://#diff-91591205e33ebfe3a7bd2bfde881b4685447349450408744f68879d6c480f51cR65)

**Front-end code update:**

* Added a comment to `frontend/public/style.css` to indicate a minor change for testing front-end deployment.